### PR TITLE
Make the ordering of prior_boxes deterministic

### DIFF
--- a/model.py
+++ b/model.py
@@ -395,7 +395,7 @@ class SSD300(nn.Module):
                          'conv10_2': [1., 2., 0.5],
                          'conv11_2': [1., 2., 0.5]}
 
-        fmaps = list(fmap_dims.keys())
+        fmaps = sorted(list(fmap_dims.keys()))
 
         prior_boxes = []
 


### PR DESCRIPTION
Hi, and thanks for the great code. It is very easy to understand.

In the current implementation the ordering of the prior_boxes-list is random. This makes it impossible to load pretrained model weights (without the model definition).

The following fix sorts the dictionary keys alphabetically which should fix this.

